### PR TITLE
TextMeshPro への移行と敵撃破数更新のイベント化

### DIFF
--- a/Assets/Scenes/OLD-FPS-plactice.unity
+++ b/Assets/Scenes/OLD-FPS-plactice.unity
@@ -749,29 +749,108 @@ MonoBehaviour:
   m_GameObject: {fileID: 105353574}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.8640462, b: 0, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 65
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 6
-    m_MaxSize: 65
-    m_Alignment: 1
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 0
+  m_text: 0
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 0}
+  m_sharedMaterial: {fileID: 0}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278246655
+  m_fontColor: {r: 1, g: 0.8640462, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 0
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyle: {fileID: 0}
+  m_TextStyleHashCode: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_outlineColor:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontSize: 65
+  m_fontSizeBase: 65
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 514
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_ignoreRectMaskCulling: 0
+  m_ignoreCulling: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isTextObjectScaleStatic: 0
+  m_VertexSortingOrder: 0
+  m_spriteAnimator: {fileID: 0}
+  m_FXMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_isFXMatrixSet: 0
 --- !u!222 &105353577
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -749,29 +749,108 @@ MonoBehaviour:
   m_GameObject: {fileID: 105353574}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 0.8640462, b: 0, a: 1}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 65
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 6
-    m_MaxSize: 65
-    m_Alignment: 1
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 0
+  m_text: 0
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 0}
+  m_sharedMaterial: {fileID: 0}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278246655
+  m_fontColor: {r: 1, g: 0.8640462, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 0
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyle: {fileID: 0}
+  m_TextStyleHashCode: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_outlineColor:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontSize: 65
+  m_fontSizeBase: 65
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 514
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_ignoreRectMaskCulling: 0
+  m_ignoreCulling: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isTextObjectScaleStatic: 0
+  m_VertexSortingOrder: 0
+  m_spriteAnimator: {fileID: 0}
+  m_FXMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_isFXMatrixSet: 0
 --- !u!222 &105353577
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Script/DestroyObject.cs
+++ b/Assets/Script/DestroyObject.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 
 public class DestroyObject : MonoBehaviour
 {
+    public static event System.Action<DestroyObject> EnemyDestroyed;
+
     public int damage;
     private GameObject tmpenemy;
     private GameObject enemy;
@@ -11,6 +13,7 @@ public class DestroyObject : MonoBehaviour
     public GameObject Particles;
 
     public int hitPoint = 100;
+    private bool isDestroyed;
 
     void Start()
     {
@@ -54,8 +57,12 @@ public class DestroyObject : MonoBehaviour
 
     void Update()
     {
-        if (hitPoint <= 0)
+        if (!isDestroyed && hitPoint <= 0)
         {
+            isDestroyed = true;
+
+            EnemyDestroyed?.Invoke(this);
+
             Destroy(gameObject);
 
             Explosion.SetActive(true);

--- a/Assets/Script/GameController.cs
+++ b/Assets/Script/GameController.cs
@@ -1,24 +1,82 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.UI;
 using UnityEngine.SceneManagement;
+using TMPro;
 
 public class GameController : MonoBehaviour
 {
-    public UnityEngine.UI.Text scoreLabel;
+    public TMP_Text scoreLabel;
     public GameObject Reticle;
     public GameObject winnerLabelObject;
     public GameObject RetryButton;
 
-    public void Update ()
-    {
-        int count = GameObject.FindGameObjectsWithTag ("Enemy").Length;
-        scoreLabel.text = count.ToString ();
+    private int remainingEnemies;
 
-        if (count == 0) {
-            // オブジェクトをアクティブにする
+    private void OnEnable()
+    {
+        DestroyObject.EnemyDestroyed += HandleEnemyDestroyed;
+    }
+
+    private void OnDisable()
+    {
+        DestroyObject.EnemyDestroyed -= HandleEnemyDestroyed;
+    }
+
+    private void Start()
+    {
+        remainingEnemies = GameObject.FindGameObjectsWithTag("Enemy").Length;
+        UpdateScoreLabel();
+
+        if (remainingEnemies == 0)
+        {
+            HandleAllEnemiesDefeated();
+        }
+        else
+        {
+            if (winnerLabelObject != null)
+            {
+                winnerLabelObject.SetActive(false);
+            }
+
+            if (Reticle != null)
+            {
+                Reticle.SetActive(true);
+            }
+        }
+    }
+
+    private void HandleEnemyDestroyed(DestroyObject enemy)
+    {
+        if (remainingEnemies > 0)
+        {
+            remainingEnemies--;
+            UpdateScoreLabel();
+
+            if (remainingEnemies == 0)
+            {
+                HandleAllEnemiesDefeated();
+            }
+        }
+    }
+
+    private void UpdateScoreLabel()
+    {
+        if (scoreLabel != null)
+        {
+            scoreLabel.text = remainingEnemies.ToString();
+        }
+    }
+
+    private void HandleAllEnemiesDefeated()
+    {
+        if (winnerLabelObject != null)
+        {
             winnerLabelObject.SetActive(true);
+        }
+
+        if (Reticle != null)
+        {
             Reticle.SetActive(false);
         }
     }


### PR DESCRIPTION
## 概要
- Canvas 上のスコア表示を TextMeshProUGUI に差し替え、GameController の参照型を TMP_Text に変更
- DestroyObject から敵撃破イベントを発行し、GameController がイベントドリブンに残敵数を更新するよう改善
- SampleScene と OLD-FPS-plactice の ScoreLabel を再保存し、勝利 UI とレティクルの表示制御を整理

## テスト
- テスト未実施（エディタ環境がないため）

------
https://chatgpt.com/codex/tasks/task_e_68e00687cba8832c8576354090ef8c7e